### PR TITLE
bugfix/error-in-methods-using-core-getFeatureCollection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,15 @@
       "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==",
       "dev": true
     },
+    "@types/mapbox-gl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-1.11.1.tgz",
+      "integrity": "sha512-dkcnCkwm3Eb2LioVUTi21LUOyaa97sAQKZ+qn6DCAkP+C2gm514hCLvm3hfHsTWGBaZuFgHoYYZbPQ/LCrwkaw==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -23,13 +32,13 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.41",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz",
-      "integrity": "sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==",
+      "version": "16.9.46",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.46.tgz",
+      "integrity": "sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "csstype": "^3.0.2"
       }
     },
     "@types/redux": {
@@ -615,9 +624,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-      "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
+      "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==",
       "dev": true
     },
     "d": {
@@ -2176,12 +2185,13 @@
       "dev": true
     },
     "jmap-core": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/jmap-core/-/jmap-core-0.5.9.tgz",
-      "integrity": "sha512-gu5Dvwyz31Q06SXcw71osnKxrX2qK4+h1dTO/WxvVLfP6G/tw8It0if4mDGPlZi/ir4q2BPPSrcTJwuV40CC2g==",
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/jmap-core/-/jmap-core-0.5.22.tgz",
+      "integrity": "sha512-tJLYP/1qzVYDF7wvvyY0GfCREVhuWEF2GNn+62t6E0AIpXXm0ONo5fa/VMzPSvLSBrMrNBdQsI8sEM5K4y3E6A==",
       "dev": true,
       "requires": {
         "@types/geojson": "^7946.0.7",
+        "@types/mapbox-gl": "^1.9.1",
         "@types/react": "^16.8.3",
         "@types/redux": "^3.6.0",
         "geojson": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jmap-app",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "JMap Application",
   "main": "src/app.ts",
   "scripts": {
@@ -23,7 +23,7 @@
   "devDependencies": {
     "gulp": "^4.0.2",
     "gulp-typedoc": "^2.2.2",
-    "jmap-core": "0.5.9",
+    "jmap-core": "0.5.22",
     "typedoc": "^0.15.0"
   }
 }

--- a/public/measure.d.ts
+++ b/public/measure.d.ts
@@ -4,7 +4,7 @@ declare interface JAppMeasure {
   id: number
   type: JAppMeasureType
   total: number
-  popups: Array<{ coordinates: [number, number], html: string }>
+  popups: Array<{ coordinates: JPoint, html: string }>
   multiPointFeature: GeoJSON.Feature<GeoJSON.MultiPoint>
   lineFeature: GeoJSON.Feature<GeoJSON.LineString>
   fillFeature: GeoJSON.Feature<GeoJSON.LineString>


### PR DESCRIPTION
use updated JPoint type everywhere that we were using number[] or [number, number]


À noter: 

Dans map-app, jmap-core est configuré en dev-dependencies seulement, et pointe vers 0.5.9, on a pas tous les changements introduits depuis 0.5.xx. Par exemple, la définition de JPoint dans map-app pointe encore vers [number, number] au lieu de [number, number] | [number, number, number]. Quand on roule npm run copy dans jmap-core, ça ne mets pas à jour jmap-app.

On fait quoi? on mets les script npm copy à jour?

